### PR TITLE
Fix hole switching bug: Reset stroke count when changing holes

### DIFF
--- a/src/main/java/de/itagile/golf/EinfacheScorecard.java
+++ b/src/main/java/de/itagile/golf/EinfacheScorecard.java
@@ -11,6 +11,7 @@ public class EinfacheScorecard implements Scorecard {
 
 	public void schliesseLochAb() {
 		aktuellesLoch++;
+		anzahlSchlaege = 0;
 	}
 
 	public int anzahlSchlaege() {

--- a/src/unittests/java/de/itagile/golf/EinfacheScorecardTest.java
+++ b/src/unittests/java/de/itagile/golf/EinfacheScorecardTest.java
@@ -27,6 +27,8 @@ class EinfacheScorecardTest {
 	void setztSchlagzahlZurueck() {
 		scorecard.erhoeheAnzahlSchlaege();
 		scorecard.schliesseLochAb();
+		
+		assertThat(scorecard.anzahlSchlaege(), is(0));
 	}
 	
 	@Test


### PR DESCRIPTION
This PR fixes the bug where stroke count wasn't being reset when switching to the next hole.

## Changes
- Fixed `schliesseLochAb()` method in `EinfacheScorecard.java` to reset stroke count
- Fixed incomplete unit test to properly verify stroke count reset

Fixes #59

Generated with [Claude Code](https://claude.ai/code)